### PR TITLE
Add reusable Slack notification workflows

### DIFF
--- a/.github/workflows/slack-notify-end.yml
+++ b/.github/workflows/slack-notify-end.yml
@@ -1,0 +1,132 @@
+name: Slack Notify End
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: Slack channel ID to post to
+        required: false
+        type: string
+        default: C01UGQ98P9U
+      ts:
+        description: Slack message timestamp from slack-notify-start output
+        required: true
+        type: string
+      start:
+        description: Job start time as epoch seconds from slack-notify-start output
+        required: true
+        type: string
+      startfmt:
+        description: Job start time formatted as ISO-8601 from slack-notify-start output
+        required: true
+        type: string
+      status:
+        description: Overall job status — success, failure, or cancelled
+        required: true
+        type: string
+    secrets:
+      SLACK_BOT_TOKEN:
+        required: true
+
+jobs:
+  notify:
+    runs-on: self-hosted
+
+    steps:
+      - name: Get end time
+        if: always()
+        run: |
+          echo "end=$(date +%s)" >> $GITHUB_ENV
+          echo "endfmt=$(date --iso-8601=minutes)" >> $GITHUB_ENV
+
+      - name: Get runtime difference
+        if: always()
+        env:
+          START: ${{ inputs.start }}
+        run: echo "timediff=$(( ($end - $START)/60 )) minutes\n$(( ($end - $START)%60 )) seconds" >> $GITHUB_ENV
+
+      - name: Set status variables
+        if: always()
+        env:
+          STATUS: ${{ inputs.status }}
+        run: |
+          case "$STATUS" in
+            success)
+              echo "colour=good" >> $GITHUB_ENV
+              echo "status=Completed" >> $GITHUB_ENV
+              echo "icon=✅" >> $GITHUB_ENV
+              ;;
+            failure)
+              echo "colour=danger" >> $GITHUB_ENV
+              echo "status=Failed" >> $GITHUB_ENV
+              echo "icon=🛑" >> $GITHUB_ENV
+              ;;
+            cancelled)
+              echo "colour=warning" >> $GITHUB_ENV
+              echo "status=Cancelled" >> $GITHUB_ENV
+              echo "icon=⚠" >> $GITHUB_ENV
+              ;;
+            *)
+              echo "colour=grey" >> $GITHUB_ENV
+              echo "status=Unknown" >> $GITHUB_ENV
+              echo "icon=❓" >> $GITHUB_ENV
+              ;;
+          esac
+
+      - name: Send Slack message
+        if: always()
+        uses: slackapi/slack-github-action@v3.0.1
+        continue-on-error: true
+        with:
+          method: chat.update
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ inputs.channel }}",
+              "ts": "${{ inputs.ts }}",
+              "attachments": [
+                {
+                  "mrkdwn_in": ["text", "pretext"],
+                  "fallback": ${{ toJSON(join(github.event.commits.*.message, '<br>') || ':clock6: Scheduled') }},
+                  "color": "${{ env.colour }}",
+                  "pretext": "${{ env.icon }} ${{ github.workflow }} (${{ github.ref_name }}) #${{ github.run_number }}",
+                  "author_name": "${{ github.triggering_actor || github.actor }}",
+                  "title": "${{ github.workflow }}",
+                  "title_link": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                  "text": ${{ toJSON(join(github.event.commits.*.message, '\n') || ':clock6: Scheduled') }},
+                  "fields": [
+                    {
+                      "title": "Status",
+                      "short": true,
+                      "value": "${{ env.status }}"
+                    },
+                    {
+                      "title": "Start",
+                      "short": true,
+                      "value": "${{ inputs.startfmt }}"
+                    },
+                    {
+                      "title": "Run time",
+                      "short": true,
+                      "value": "${{ env.timediff }}"
+                    },
+                    {
+                      "title": "End",
+                      "short": true,
+                      "value": "${{ env.endfmt }}"
+                    }
+                  ]
+                },
+                {
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "<${{ github.event.pull_request.html_url || github.event.head_commit.url || github.server_url }}|View commit>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/slack-notify-start.yml
+++ b/.github/workflows/slack-notify-start.yml
@@ -1,0 +1,85 @@
+name: Slack Notify Start
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: Slack channel ID to post to
+        required: false
+        type: string
+        default: C01UGQ98P9U
+    secrets:
+      SLACK_BOT_TOKEN:
+        required: true
+    outputs:
+      ts:
+        description: Slack message timestamp (pass to slack-notify-end to update the message)
+        value: ${{ jobs.notify.outputs.ts }}
+      start:
+        description: Job start time as epoch seconds (pass to slack-notify-end for runtime calculation)
+        value: ${{ jobs.notify.outputs.start }}
+      startfmt:
+        description: Job start time formatted as ISO-8601 (pass to slack-notify-end for display)
+        value: ${{ jobs.notify.outputs.startfmt }}
+
+jobs:
+  notify:
+    runs-on: self-hosted
+    outputs:
+      ts: ${{ steps.slack.outputs.ts }}
+      start: ${{ steps.jobstart.outputs.start }}
+      startfmt: ${{ steps.jobstart.outputs.startfmt }}
+
+    steps:
+      - name: Get start time
+        id: jobstart
+        run: |
+          echo "start=$(date +%s)" >> $GITHUB_OUTPUT
+          echo "startfmt=$(date --iso-8601=minutes)" >> $GITHUB_OUTPUT
+
+      - name: Send Slack message
+        id: slack
+        uses: slackapi/slack-github-action@v3.0.1
+        continue-on-error: true
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ inputs.channel }}",
+              "attachments": [
+                {
+                  "mrkdwn_in": ["text", "pretext"],
+                  "fallback": ${{ toJSON(join(github.event.commits.*.message, '<br>') || ':clock6: Scheduled') }},
+                  "color": "grey",
+                  "pretext": ":checkered_flag: ${{ github.workflow }} (${{ github.ref_name }}) #${{ github.run_number }}",
+                  "author_name": "${{ github.triggering_actor || github.actor }}",
+                  "title": "${{ github.workflow }}",
+                  "title_link": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                  "text": ${{ toJSON(join(github.event.commits.*.message, '\n') || ':clock6: Scheduled') }},
+                  "fields": [
+                    {
+                      "title": "Status",
+                      "short": true,
+                      "value": "In Progress"
+                    },
+                    {
+                      "title": "Start",
+                      "short": true,
+                      "value": "${{ steps.jobstart.outputs.startfmt }}"
+                    }
+                  ]
+                },
+                {
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "<${{ github.event.pull_request.html_url || github.event.head_commit.url || github.server_url }}|View commit>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,106 @@ Where I store my re-usable actions
 
 In here, there is:
 
+# Slack Notifications
+
+Two reusable workflows that handle Slack notifications for GitHub Actions runs. They post a start message when a workflow begins and update it with the final status, timing, and colour when it finishes.
+
+## slack-notify-start
+
+Posts an initial "In Progress" Slack message via `chat.postMessage` and outputs the timing values needed by `slack-notify-end`.
+
+### Inputs
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `channel` | No | `C01UGQ98P9U` | Slack channel ID to post to |
+
+### Secrets
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `SLACK_BOT_TOKEN` | Yes | Slack bot token with `chat:write` permission |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| `ts` | Slack message timestamp — pass to `slack-notify-end` |
+| `start` | Start time as epoch seconds — pass to `slack-notify-end` |
+| `startfmt` | Start time formatted as ISO-8601 — pass to `slack-notify-end` |
+
+### Usage
+
+```yaml
+jobs:
+  slack-start:
+    uses: pgmac/pg-actions/.github/workflows/slack-notify-start.yml@main
+    secrets: inherit
+
+  run:
+    needs: [slack-start]
+    runs-on: self-hosted
+    steps:
+      - run: echo "do the work here"
+
+  slack-end:
+    if: always()
+    needs: [slack-start, run]
+    uses: pgmac/pg-actions/.github/workflows/slack-notify-end.yml@main
+    with:
+      ts: ${{ needs.slack-start.outputs.ts }}
+      start: ${{ needs.slack-start.outputs.start }}
+      startfmt: ${{ needs.slack-start.outputs.startfmt }}
+      status: ${{ needs.run.result }}
+    secrets: inherit
+```
+
+For multi-job workflows where you want the overall status to reflect several parallel jobs:
+
+```yaml
+  slack-end:
+    if: always()
+    needs: [slack-start, job-a, job-b, job-c]
+    uses: pgmac/pg-actions/.github/workflows/slack-notify-end.yml@main
+    with:
+      ts: ${{ needs.slack-start.outputs.ts }}
+      start: ${{ needs.slack-start.outputs.start }}
+      startfmt: ${{ needs.slack-start.outputs.startfmt }}
+      status: ${{ (needs.job-a.result == 'failure' || needs.job-b.result == 'failure' || needs.job-c.result == 'failure') && 'failure' || (needs.job-a.result == 'cancelled' || needs.job-b.result == 'cancelled' || needs.job-c.result == 'cancelled') && 'cancelled' || 'success' }}
+    secrets: inherit
+```
+
+## slack-notify-end
+
+Updates the Slack message posted by `slack-notify-start` with the final status, colour, and timing information.
+
+### Inputs
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `channel` | No | `C01UGQ98P9U` | Slack channel ID |
+| `ts` | Yes | — | Slack message timestamp from `slack-notify-start` |
+| `start` | Yes | — | Start time as epoch seconds from `slack-notify-start` |
+| `startfmt` | Yes | — | Start time formatted as ISO-8601 from `slack-notify-start` |
+| `status` | Yes | — | Overall job status: `success`, `failure`, or `cancelled` |
+
+### Secrets
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `SLACK_BOT_TOKEN` | Yes | Slack bot token with `chat:write` permission |
+
+### Status colours
+
+| Status | Slack colour | Icon |
+|--------|-------------|------|
+| `success` | `good` (green) | ✅ |
+| `failure` | `danger` (red) | 🛑 |
+| `cancelled` | `warning` (yellow) | ⚠ |
+| anything else | `grey` | ❓ |
+
+---
+
 # sbom
 
 This will:


### PR DESCRIPTION
## Summary

- Adds `slack-notify-start.yml` — posts an initial "In Progress" Slack message via `chat.postMessage`, outputs `ts`/`start`/`startfmt` for the end workflow
- Adds `slack-notify-end.yml` — takes those outputs as inputs, determines colour/icon from `status` input, updates the message with timing via `chat.update`
- Updates `README.md` with full usage documentation for both workflows, including single-job and multi-job examples

## Test plan

- [x] Merge pg-actions PR first so `@main` reference resolves
- [ ] Trigger one of the ansible workflows (e.g. DNS Update via `workflow_dispatch`) and verify start + end Slack messages appear correctly
- [ ] Cancel a run mid-flight and verify the cancelled (yellow) status appears
- [ ] Check that a failing run shows the failure (red) status

🤖 Generated with [Claude Code](https://claude.com/claude-code)