### PR TITLE
feat: add OpenSSF Scorecard reusable workflows

### DIFF
--- a/.github/workflows/scorecard-private.yml
+++ b/.github/workflows/scorecard-private.yml
@@ -1,0 +1,42 @@
+name: OpenSSF Scorecard (private)
+
+# Reusable workflow for private repositories.
+# Runs the OpenSSF Scorecard checks and uploads results as an artifact only.
+# Results are NOT published to the OpenSSF public API or the GitHub Security tab
+# (GHAS code scanning is a paid feature for private repos on free-tier GitHub).
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: "Runner to use for the job"
+        required: false
+        type: string
+        default: "self-hosted"
+
+jobs:
+  scorecard:
+    name: Scorecard analysis
+    runs-on: ${{ inputs.runs-on || 'self-hosted' }}
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: false
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: scorecard-results.sarif
+          retention-days: 30

--- a/.github/workflows/scorecard-public.yml
+++ b/.github/workflows/scorecard-public.yml
@@ -1,0 +1,61 @@
+name: OpenSSF Scorecard (public)
+
+# Reusable workflow for public repositories.
+# Runs the OpenSSF Scorecard checks and uploads results as an artifact and
+# to the GitHub Security tab (SARIF). Results are NOT published to the OpenSSF
+# public API (publish_results: false).
+
+on:
+  push:
+    branches: ["main", "master"]
+  schedule:
+    - cron: "0 14 * * 0" # 00:00 AEST every Sunday
+  workflow_dispatch:
+    inputs:
+      runs-on:
+        description: "Runner to use for the job"
+        required: false
+        type: choice
+        options:
+          - self-hosted
+        default: "self-hosted"
+  workflow_call:
+    inputs:
+      runs-on:
+        description: "Runner to use for the job"
+        required: false
+        type: string
+        default: "self-hosted"
+
+jobs:
+  scorecard:
+    name: Scorecard analysis
+    runs-on: ${{ inputs.runs-on || 'self-hosted' }}
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: false
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: scorecard-results.sarif
+          retention-days: 30
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: scorecard-results.sarif

--- a/README.md
+++ b/README.md
@@ -104,6 +104,71 @@ Updates the Slack message posted by `slack-notify-start` with the final status, 
 
 ---
 
+# OpenSSF Scorecard
+
+Two reusable workflows that run [OpenSSF Scorecard](https://scorecard.dev/) security checks against your repository. Results are kept local — nothing is published to the OpenSSF public API.
+
+## scorecard-public
+
+For **public** repositories. Runs the full Scorecard check suite, uploads results as an artifact, and uploads the SARIF report to the GitHub Security tab.
+
+Also runs automatically on push to `main`/`master` and on a weekly schedule (Sunday midnight AEST) when used directly in `pg-actions`.
+
+### Inputs
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `runs-on` | No | `self-hosted` | Runner label |
+
+### Permissions required in caller
+
+```yaml
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+```
+
+### Usage
+
+```yaml
+jobs:
+  scorecard:
+    uses: pgmac-net/pg-actions/.github/workflows/scorecard-public.yml@main
+```
+
+---
+
+## scorecard-private
+
+For **private** repositories. Runs Scorecard checks and uploads results as an artifact only. The GitHub Security tab upload is skipped (GHAS code scanning requires a paid plan for private repos).
+
+Only callable via `workflow_call` — no standalone schedule trigger.
+
+### Inputs
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `runs-on` | No | `self-hosted` | Runner label |
+
+### Permissions required in caller
+
+```yaml
+permissions:
+  contents: read
+  actions: read
+```
+
+### Usage
+
+```yaml
+jobs:
+  scorecard:
+    uses: pgmac-net/pg-actions/.github/workflows/scorecard-private.yml@main
+```
+
+---
+
 # sbom
 
 This will:


### PR DESCRIPTION
## Summary

- Adds `scorecard-public.yml` — reusable Scorecard workflow for public repos; uploads SARIF to GitHub Security tab; `publish_results: false` (no external publishing)
- Adds `scorecard-private.yml` — reusable Scorecard workflow for private repos; SARIF artifact only (GHAS not available on free tier for private repos)
- Updates README with usage docs for both workflows

## Test plan

- [ ] Call `scorecard-public.yml` from a public repo workflow and verify SARIF artifact is created
- [ ] Call `scorecard-private.yml` from a private repo workflow and verify SARIF artifact is created
- [ ] Confirm no results are published to the OpenSSF public API

Closes PGM-130 (partial — Terraform repos are separate local repos not yet pushed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)