### PR TITLE
fix: pin ossf/scorecard-action to commit hash for v2.4.3

### DIFF
--- a/.github/workflows/scorecard-private.yml
+++ b/.github/workflows/scorecard-private.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: scorecard-results.sarif
           results_format: sarif

--- a/.github/workflows/scorecard-public.yml
+++ b/.github/workflows/scorecard-public.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: scorecard-results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

- `ossf/scorecard-action@v2` floating tag no longer exists upstream, causing both scorecard workflows to fail with "v2 not found"
- Pins both `scorecard-public.yml` and `scorecard-private.yml` to the exact commit hash of v2.4.3 (`4eaacf0543bb3f2c246792bd56e8cdeffafb205a`) with a `# v2.4.3` comment for readability
- Fixes: https://github.com/pgmac-net/pg-actions/actions/runs/24959171032/job/73082693742

## Test plan

- [ ] Scorecard workflow runs successfully on merge to main
- [ ] Both public and private scorecard variants complete without "not found" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)