### PR TITLE
fix(ci): add container directive to slack-notify reusable workflows

### DIFF
--- a/.github/workflows/slack-notify-end.yml
+++ b/.github/workflows/slack-notify-end.yml
@@ -31,6 +31,8 @@ on:
 jobs:
   notify:
     runs-on: self-hosted
+    container:
+      image: ubuntu:24.04
 
     steps:
       - name: Get end time

--- a/.github/workflows/slack-notify-start.yml
+++ b/.github/workflows/slack-notify-start.yml
@@ -25,6 +25,8 @@ on:
 jobs:
   notify:
     runs-on: self-hosted
+    container:
+      image: ubuntu:24.04
     outputs:
       ts: ${{ steps.slack.outputs.ts }}
       start: ${{ steps.jobstart.outputs.start }}


### PR DESCRIPTION
## Summary

- Adds `container: ubuntu:24.04` to `slack-notify-start.yml` and `slack-notify-end.yml`
- These reusable workflows had `runs-on: self-hosted` but no `container:`, causing them to fail on ARC runner 2.334 with kubernetes container mode enabled
- Every ansible workflow that calls these (`dns.yml`, `update.yml`, `sbom-servers.yml`, `pvek8s_node_reboot.yml`, `microk8s-weekly-maintenance.yml`) was failing in the `slack-start`/`slack-end` steps

## Context

The root fix is in `pgmac-net/pgk8s` (setting `ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER=false` on the runnersets). This PR adds explicit container declarations for architectural cleanliness — the workflows now declare their environment regardless of what the runner enforces.

Relates to PGM-169.

## Test plan

- [ ] Any ansible workflow completes its `slack-start` and `slack-end` steps without error
- [ ] Slack notification messages appear as expected in the builds channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)