### PR TITLE
feat(pgm-175): dependabot vulnerability management workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,11 +30,17 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Install Claude Code
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          echo "CLAUDE_BIN=$(which claude)" >> "$GITHUB_ENV"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          path_to_claude_code_executable: ${{ env.CLAUDE_BIN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/dependabot-alert.yml
+++ b/.github/workflows/dependabot-alert.yml
@@ -1,0 +1,25 @@
+name: Dependabot Alert
+
+on:
+  dependabot_alert:
+    types: [created, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  manage:
+    if: contains(fromJSON('["high", "critical"]'), github.event.alert.security_vulnerability.severity)
+    uses: pgmac-net/pg-actions/.github/workflows/dependabot-management.yml@main
+    with:
+      alert_number: ${{ github.event.alert.number }}
+      package_name: ${{ github.event.alert.dependency.package.name }}
+      package_ecosystem: ${{ github.event.alert.dependency.package.ecosystem }}
+      severity: ${{ github.event.alert.security_vulnerability.severity }}
+      summary: ${{ github.event.alert.security_advisory.summary }}
+      cve_id: ${{ github.event.alert.security_advisory.cve_id }}
+      ghsa_id: ${{ github.event.alert.security_advisory.ghsa_id }}
+      vulnerable_version_range: ${{ github.event.alert.security_vulnerability.vulnerable_version_range }}
+      first_patched_version: ${{ github.event.alert.security_vulnerability.first_patched_version.identifier }}
+    secrets: inherit

--- a/.github/workflows/dependabot-management.yml
+++ b/.github/workflows/dependabot-management.yml
@@ -1,0 +1,335 @@
+name: Dependabot Vulnerability Management
+
+on:
+  workflow_call:
+    inputs:
+      alert_number:
+        description: Dependabot alert number
+        required: true
+        type: number
+      package_name:
+        description: Vulnerable package name
+        required: true
+        type: string
+      package_ecosystem:
+        description: Package ecosystem (npm, pip, maven, etc.)
+        required: true
+        type: string
+      severity:
+        description: Vulnerability severity (critical, high, medium, low)
+        required: true
+        type: string
+      summary:
+        description: Vulnerability summary
+        required: true
+        type: string
+      cve_id:
+        description: CVE ID if available
+        required: false
+        type: string
+        default: ""
+      ghsa_id:
+        description: GitHub Security Advisory ID
+        required: true
+        type: string
+      vulnerable_version_range:
+        description: Affected version range
+        required: true
+        type: string
+      first_patched_version:
+        description: First version that contains the fix
+        required: false
+        type: string
+        default: ""
+    secrets:
+      LINEAR_API_KEY:
+        required: true
+      ANTHROPIC_API_KEY:
+        required: false
+
+jobs:
+  create-linear-ticket:
+    name: Create Linear Ticket
+    runs-on: self-hosted
+    outputs:
+      ticket_identifier: ${{ steps.create-ticket.outputs.ticket_identifier || steps.check-existing.outputs.ticket_identifier }}
+      ticket_url: ${{ steps.create-ticket.outputs.ticket_url || steps.check-existing.outputs.ticket_url }}
+    steps:
+      - name: Check for existing ticket
+        id: check-existing
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          GHSA_ID: ${{ inputs.ghsa_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          PAYLOAD=$(jq -n \
+            --arg ghsa "$GHSA_ID" \
+            --arg repo "$REPO" \
+            '{
+              query: "query FindIssue($filter: IssueFilter) { issues(filter: $filter) { nodes { id identifier url } } }",
+              variables: {
+                filter: {
+                  team: { id: { eq: "0b2f2134-ef52-46dc-9fef-71d77d89aca9" } },
+                  and: [
+                    { title: { containsIgnoreCase: $ghsa } },
+                    { title: { containsIgnoreCase: $repo } }
+                  ]
+                }
+              }
+            }')
+
+          RESPONSE=$(curl -s -X POST https://api.linear.app/graphql \
+            -H "Authorization: ${LINEAR_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+
+          COUNT=$(echo "$RESPONSE" | jq '.data.issues.nodes | length')
+          if [ "${COUNT}" -gt "0" ]; then
+            IDENTIFIER=$(echo "$RESPONSE" | jq -r '.data.issues.nodes[0].identifier')
+            URL=$(echo "$RESPONSE" | jq -r '.data.issues.nodes[0].url')
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "ticket_identifier=${IDENTIFIER}" >> "$GITHUB_OUTPUT"
+            echo "ticket_url=${URL}" >> "$GITHUB_OUTPUT"
+            echo "Existing ticket found: ${IDENTIFIER}"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No existing ticket for ${GHSA_ID} in ${REPO}"
+          fi
+
+      - name: Create ticket
+        id: create-ticket
+        if: steps.check-existing.outputs.exists != 'true'
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          GHSA_ID: ${{ inputs.ghsa_id }}
+          REPO: ${{ github.repository }}
+          PACKAGE_NAME: ${{ inputs.package_name }}
+          PACKAGE_ECOSYSTEM: ${{ inputs.package_ecosystem }}
+          SEVERITY: ${{ inputs.severity }}
+          SUMMARY: ${{ inputs.summary }}
+          CVE_ID: ${{ inputs.cve_id }}
+          VULN_RANGE: ${{ inputs.vulnerable_version_range }}
+          PATCHED_VERSION: ${{ inputs.first_patched_version }}
+          ALERT_NUMBER: ${{ inputs.alert_number }}
+        run: |
+          case "$SEVERITY" in
+            critical) PRIORITY=1 ;;
+            high)     PRIORITY=2 ;;
+            *)        PRIORITY=3 ;;
+          esac
+
+          ALERT_URL="https://github.com/${REPO}/security/dependabot/${ALERT_NUMBER}"
+          CVE_TEXT="${CVE_ID:-N/A}"
+          PATCHED_TEXT="${PATCHED_VERSION:-None available}"
+
+          DESCRIPTION="## Dependabot Security Alert
+
+**Repository:** ${REPO}
+**Package:** ${PACKAGE_NAME} (${PACKAGE_ECOSYSTEM})
+**Severity:** ${SEVERITY}
+**GHSA:** [${GHSA_ID}](https://github.com/advisories/${GHSA_ID})
+**CVE:** ${CVE_TEXT}
+**Vulnerable versions:** ${VULN_RANGE}
+**First patched version:** ${PATCHED_TEXT}
+
+[View Dependabot Alert](${ALERT_URL})
+
+---
+A draft fix PR will be created automatically via Claude Code."
+
+          PAYLOAD=$(jq -n \
+            --arg title "[${REPO}] ${GHSA_ID}: ${SUMMARY}" \
+            --arg description "$DESCRIPTION" \
+            --argjson priority "$PRIORITY" \
+            '{
+              query: "mutation CreateIssue($input: IssueCreateInput!) { issueCreate(input: $input) { success issue { id identifier url } } }",
+              variables: {
+                input: {
+                  teamId: "0b2f2134-ef52-46dc-9fef-71d77d89aca9",
+                  projectId: "222fe574-e2cd-42e8-9d82-ca27e5303dec",
+                  title: $title,
+                  description: $description,
+                  priority: $priority,
+                  labelIds: [
+                    "b8896161-52fe-436b-915e-03c50f909671",
+                    "c57b4706-1b7b-4d80-9e2c-3a79a0ef4380"
+                  ]
+                }
+              }
+            }')
+
+          RESPONSE=$(curl -s -X POST https://api.linear.app/graphql \
+            -H "Authorization: ${LINEAR_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+
+          IDENTIFIER=$(echo "$RESPONSE" | jq -r '.data.issueCreate.issue.identifier')
+          URL=$(echo "$RESPONSE" | jq -r '.data.issueCreate.issue.url')
+
+          if [ "$IDENTIFIER" = "null" ] || [ -z "$IDENTIFIER" ]; then
+            echo "Error creating Linear ticket:"
+            echo "$RESPONSE" | jq .
+            exit 1
+          fi
+
+          echo "ticket_identifier=${IDENTIFIER}" >> "$GITHUB_OUTPUT"
+          echo "ticket_url=${URL}" >> "$GITHUB_OUTPUT"
+          echo "Created Linear ticket: ${IDENTIFIER}"
+
+  create-fix-pr:
+    name: Create Fix PR via Claude Code
+    needs: create-linear-ticket
+    runs-on: self-hosted
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check ANTHROPIC_API_KEY
+        id: check-key
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          TICKET_URL: ${{ needs.create-linear-ticket.outputs.ticket_url }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "ANTHROPIC_API_KEY not set — skipping PR creation"
+            echo "Fix manually: ${TICKET_URL}"
+          fi
+
+      - name: Check for existing PR
+        id: check-pr
+        if: steps.check-key.outputs.available == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GHSA_ID: ${{ inputs.ghsa_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          COUNT=$(gh pr list \
+            --repo "$REPO" \
+            --search "${GHSA_ID} in:title" \
+            --state open \
+            --json number \
+            --jq '. | length')
+          echo "exists=$([ "${COUNT}" -gt "0" ] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        if: steps.check-key.outputs.available == 'true' && steps.check-pr.outputs.exists != 'true'
+
+      - name: Create fix branch
+        id: branch
+        if: steps.check-key.outputs.available == 'true' && steps.check-pr.outputs.exists != 'true'
+        env:
+          GHSA_ID: ${{ inputs.ghsa_id }}
+        run: |
+          BRANCH="fix/dependabot/${GHSA_ID}"
+          git checkout -b "$BRANCH"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude Code to fix vulnerability
+        if: steps.check-key.outputs.available == 'true' && steps.check-pr.outputs.exists != 'true'
+        uses: anthropics/claude-code-base-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: "Bash,Read,Write,Edit,Glob,Grep"
+          timeout_minutes: "15"
+          prompt: |
+            Fix the following Dependabot security vulnerability in this repository:
+
+            Package: ${{ inputs.package_name }} (${{ inputs.package_ecosystem }})
+            Severity: ${{ inputs.severity }}
+            Vulnerability: ${{ inputs.summary }}
+            GHSA ID: ${{ inputs.ghsa_id }}
+            CVE: ${{ inputs.cve_id || 'N/A' }}
+            Vulnerable version range: ${{ inputs.vulnerable_version_range }}
+            First patched version: ${{ inputs.first_patched_version || 'latest stable' }}
+            Linear ticket: ${{ needs.create-linear-ticket.outputs.ticket_identifier }}
+
+            Steps:
+            1. Update ${{ inputs.package_name }} to version ${{ inputs.first_patched_version || 'the latest stable version' }} or later
+            2. Update any lock files (package-lock.json, yarn.lock, requirements.txt, poetry.lock, etc.)
+            3. Fix any breaking API changes introduced by the version upgrade
+            4. Keep changes minimal — only what resolves this specific vulnerability
+            5. Do not commit or create a PR — the workflow handles that
+
+      - name: Check for changes
+        id: changes
+        if: steps.check-key.outputs.available == 'true' && steps.check-pr.outputs.exists != 'true'
+        run: |
+          if git diff --quiet && git diff --staged --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: >-
+          steps.check-key.outputs.available == 'true' &&
+          steps.check-pr.outputs.exists != 'true' &&
+          steps.changes.outputs.has_changes == 'true'
+        env:
+          PACKAGE_NAME: ${{ inputs.package_name }}
+          GHSA_ID: ${{ inputs.ghsa_id }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "fix: update ${PACKAGE_NAME} to address ${GHSA_ID}"
+          git push origin "$BRANCH"
+
+      - name: Create draft PR
+        if: >-
+          steps.check-key.outputs.available == 'true' &&
+          steps.check-pr.outputs.exists != 'true' &&
+          steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          ALERT_NUMBER: ${{ inputs.alert_number }}
+          SUMMARY: ${{ inputs.summary }}
+          PACKAGE_NAME: ${{ inputs.package_name }}
+          PACKAGE_ECOSYSTEM: ${{ inputs.package_ecosystem }}
+          SEVERITY: ${{ inputs.severity }}
+          GHSA_ID: ${{ inputs.ghsa_id }}
+          CVE_ID: ${{ inputs.cve_id }}
+          VULN_RANGE: ${{ inputs.vulnerable_version_range }}
+          PATCHED_VERSION: ${{ inputs.first_patched_version }}
+          TICKET_URL: ${{ needs.create-linear-ticket.outputs.ticket_url }}
+          TICKET_ID: ${{ needs.create-linear-ticket.outputs.ticket_identifier }}
+        run: |
+          gh pr create \
+            --draft \
+            --repo "$REPO" \
+            --head "$BRANCH" \
+            --title "fix(${PACKAGE_NAME}): address ${GHSA_ID}" \
+            --body "## Security Vulnerability Fix
+
+Addresses Dependabot alert #${ALERT_NUMBER}: **${SUMMARY}**
+
+| Field | Value |
+|-------|-------|
+| Package | \`${PACKAGE_NAME}\` (${PACKAGE_ECOSYSTEM}) |
+| Severity | ${SEVERITY} |
+| GHSA | [${GHSA_ID}](https://github.com/advisories/${GHSA_ID}) |
+| CVE | ${CVE_ID:-N/A} |
+| Vulnerable range | ${VULN_RANGE} |
+| Fixed in | ${PATCHED_VERSION:-latest} |
+
+**Linear:** [${TICKET_ID}](${TICKET_URL})
+
+> 🤖 Generated by [Claude Code](https://claude.ai/claude-code) via [dependabot-management](https://github.com/pgmac-net/pg-actions)"
+
+      - name: No automatic fix available
+        if: >-
+          steps.check-key.outputs.available == 'true' &&
+          steps.check-pr.outputs.exists != 'true' &&
+          steps.changes.outputs.has_changes == 'false'
+        env:
+          GHSA_ID: ${{ inputs.ghsa_id }}
+          TICKET_URL: ${{ needs.create-linear-ticket.outputs.ticket_url }}
+        run: |
+          echo "Claude Code could not generate an automatic fix for ${GHSA_ID}."
+          echo "Manual fix required. Linear: ${TICKET_URL}"

--- a/.github/workflows/dependabot-management.yml
+++ b/.github/workflows/dependabot-management.yml
@@ -44,7 +44,7 @@ on:
     secrets:
       LINEAR_API_KEY:
         required: true
-      ANTHROPIC_API_KEY:
+      CLAUDE_CODE_OAUTH_TOKEN:
         required: false
 
 jobs:
@@ -184,17 +184,17 @@ A draft fix PR will be created automatically via Claude Code."
       contents: write
       pull-requests: write
     steps:
-      - name: Check ANTHROPIC_API_KEY
+      - name: Check CLAUDE_CODE_OAUTH_TOKEN
         id: check-key
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           TICKET_URL: ${{ needs.create-linear-ticket.outputs.ticket_url }}
         run: |
-          if [ -n "$ANTHROPIC_API_KEY" ]; then
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "ANTHROPIC_API_KEY not set — skipping PR creation"
+            echo "CLAUDE_CODE_OAUTH_TOKEN not set — skipping PR creation"
             echo "Fix manually: ${TICKET_URL}"
           fi
 
@@ -231,7 +231,7 @@ A draft fix PR will be created automatically via Claude Code."
         if: steps.check-key.outputs.available == 'true' && steps.check-pr.outputs.exists != 'true'
         uses: anthropics/claude-code-base-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_tools: "Bash,Read,Write,Edit,Glob,Grep"
           timeout_minutes: "15"
           prompt: |


### PR DESCRIPTION
## Summary

- Adds `dependabot-management.yml` — reusable workflow called by any repo that creates a Linear ticket and a Claude Code draft fix PR for high/critical Dependabot alerts
- Adds `dependabot-alert.yml` — per-repo event handler that calls the reusable workflow on `dependabot_alert.created/reopened`

## How it works

1. `dependabot_alert` event fires in a repo → `dependabot-alert.yml` triggers (high/critical only)
2. Calls `dependabot-management.yml` which:
   - Searches Linear for an existing ticket; creates one if not found (Security + Bug labels, urgent/high priority)
   - Checks ANTHROPIC_API_KEY is set; if so, creates a fix branch and runs `anthropics/claude-code-base-action` to update the vulnerable package
   - Opens a draft PR referencing the Linear ticket

## Secrets required (org-level)
- `LINEAR_API_KEY` — already available
- `ANTHROPIC_API_KEY` — add once available (PR creation is skipped gracefully until then)

## Test plan
- [ ] Verify `dependabot-alert.yml` is excluded from `dependabot-management.yml` (no circular call)
- [ ] Manually dispatch or wait for a new high/critical Dependabot alert
- [ ] Confirm Linear ticket is created with Security + Bug labels
- [ ] Confirm draft PR is created once ANTHROPIC_API_KEY is set

Closes PGM-175 (Phase 1)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)