### PR TITLE
fix(ci): remove trailing blank line from claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,4 +54,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
-


### PR DESCRIPTION
## Summary

- Trailing blank line at EOF violated yamllint `empty-lines` rule (`max-end: 0` from default config)
- This file is distributed to all managed repos via Terraform; repos with strict YAML linting (e.g. pgk8s) fail CI when Renovate PRs touch the file

## Impact

- Fixes yamllint failure in pgmac-net/pgk8s#442 (Renovate github-actions PR)
- Prevents recurrence after next Terraform apply distributes the updated source

🤖 Generated with [Claude Code](https://claude.com/claude-code)