### PR TITLE
fix(dependabot): add security-events perm + graceful API error handling

### DIFF
--- a/.github/workflows/dependabot-alert.yml
+++ b/.github/workflows/dependabot-alert.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  security-events: read
 
 jobs:
   get-alerts:
@@ -23,10 +24,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          ALERTS=$(curl -s \
+          RESPONSE=$(curl -s \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${REPO}/dependabot/alerts?per_page=100" | \
+            "https://api.github.com/repos/${REPO}/dependabot/alerts?per_page=100")
+
+          if ! echo "$RESPONSE" | jq -e 'type == "array"' > /dev/null 2>&1; then
+            echo "Dependabot alerts unavailable: $(echo "$RESPONSE" | jq -r '.message // "unknown error"')"
+            echo "has_alerts=false" >> "$GITHUB_OUTPUT"
+            echo "matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          ALERTS=$(echo "$RESPONSE" | \
             jq '[.[] | select(.state == "open") | select(.security_vulnerability.severity | test("^(high|critical)$"))]')
 
           COUNT=$(echo "$ALERTS" | jq 'length')


### PR DESCRIPTION
## Problem

All distributed `dependabot-alert.yml` runs failing with:

```
jq: error (at <stdin>:5): Cannot index string with string "state"
```

Two root causes:

**1. Missing `security-events: read` permission**
The workflow has a `permissions:` block but not `security-events: read`. When a `permissions` block is present, unlisted permissions default to `none`. The Dependabot alerts API requires this scope — without it the API returns a 403 JSON object instead of an array, causing jq to fail.

**2. No error handling for non-array responses**
Repos without Dependabot enabled will always return an error object. Without a type check, jq crashes instead of treating it as "no alerts".

## Fix

- Add `security-events: read` to the top-level `permissions` block
- Capture the raw curl response first, check `type == "array"` before filtering; log the API message and exit cleanly with no alerts if not

## After merge
Run `terraform apply` in `terraform-github` to re-distribute the updated `dependabot-alert.yml` to all managed repos.

## Test plan
- [ ] Merge to main
- [ ] `terraform apply` in `terraform-github`
- [ ] Manually trigger workflow in a previously-failing repo (e.g. `tempplot`, `ansible-role-nomad`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)