### PR TITLE
fix(dependabot): reduce scan frequency to weekly (Monday 02:00 AEST)

### DIFF
--- a/.github/workflows/dependabot-alert.yml
+++ b/.github/workflows/dependabot-alert.yml
@@ -2,7 +2,7 @@ name: Dependabot Alert Management
 
 on:
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: '0 16 * * 0'  # Monday 02:00 AEST (UTC+10)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Change schedule from `0 */6 * * *` (every 6 hours) to `0 16 * * 0` (Monday 02:00 AEST / 16:00 UTC Sunday)
- `workflow_dispatch` manual trigger unchanged

## Test plan
- [ ] Merge and verify next scheduled run fires Monday ~02:00 AEST
- [ ] Manually trigger via Actions UI to confirm `workflow_dispatch` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)