### PR TITLE
chore: disable scheduled dependabot alert management workflow

### DIFF
--- a/.github/workflows/dependabot-alert.yml
+++ b/.github/workflows/dependabot-alert.yml
@@ -1,8 +1,6 @@
 name: Dependabot Alert Management
 
 on:
-  schedule:
-    - cron: '0 16 * * 0'  # Monday 02:00 AEST (UTC+10)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Removes the weekly `schedule` cron trigger from the Dependabot Alert Management workflow
- Retains `workflow_dispatch` so it can still be triggered manually when needed
- Once merged, Terraform (`terraform-github`) will propagate the updated file to all 52 managed repos on next apply

## Test plan

- [ ] Confirm workflow no longer appears in scheduled runs after merge
- [ ] Confirm `terraform apply` in terraform-github updates all repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)