### PR TITLE
fix(sbom): use mise install script instead of GitHub releases download

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -128,6 +128,8 @@ jobs:
 
       - name: Install tools via mise
         uses: jdx/mise-action@v4
+        with:
+          fetch_from_github: false
 
       - name: Download the SBoM Artifact
         uses: actions/download-artifact@v8.0.1


### PR DESCRIPTION
## Summary

- `jdx/mise-action@v4` with `fetch_from_github: true` (default) downloads the mise binary directly from GitHub releases
- When a new mise version is freshly cut, release assets can briefly 404 while being published — this is what caused the failure in run [27491105710](https://github.com/pgmac-net/pg-actions/actions/runs/27491105710/job/81256333106): mise `v2026.6.7` was detected via the VERSION endpoint but `mise-v2026.6.7-linux-x64.tar.gz` wasn't yet available on GitHub releases
- `fetch_from_github: false` uses the mise install script (`curl mise.jdx.dev/install.sh`) which downloads from the CDN and is available immediately after a release

## Test plan

- [ ] Trigger SBOM workflow — `Install tools via mise` step downloads and installs mise without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)