### PR TITLE
fix(sbom): replace DependencyTrack/gh-upload-sbom node20 action with curl

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -83,15 +83,27 @@ jobs:
           push-to-registry: false
 
       - name: Upload SBoM to Dependency Track
-        uses: DependencyTrack/gh-upload-sbom@v3
-        with:
-          serverhostname: "${{ secrets.DT_HOST }}"
-          apikey: ${{ secrets.DT_APIKEY }}
-          projectname: ${{ github.repository }}
-          projectversion: ${{ github.sha }}
-          projecttags: ${{ github.repository }}, ${{ github.ref_type }}, ${{ github.ref}}
-          bomfilename: "sbom.json"
-          autocreate: true
+        env:
+          DT_HOST: ${{ secrets.DT_HOST }}
+          DT_APIKEY: ${{ secrets.DT_APIKEY }}
+          PROJECT_NAME: ${{ github.repository }}
+          PROJECT_VERSION: ${{ github.sha }}
+          PROJECT_TAGS: "${{ github.repository }}, ${{ github.ref_type }}, ${{ github.ref }}"
+        run: |
+          BOM_B64=$(base64 -w 0 sbom.json)
+          [[ "${BOM_B64}" == 77u/* ]] && BOM_B64="${BOM_B64:4}"
+          TAGS=$(printf '%s' "${PROJECT_TAGS}" | jq -Rc 'split(",") | map(gsub("^ +| +$"; "") | {name: .})')
+          PAYLOAD=$(jq -n \
+            --arg name "${PROJECT_NAME}" \
+            --arg version "${PROJECT_VERSION}" \
+            --argjson tags "${TAGS}" \
+            --arg bom "${BOM_B64}" \
+            '{projectName: $name, projectVersion: $version, autoCreate: true, bom: $bom, projectTags: $tags}')
+          curl -sf -X PUT \
+            -H "X-Api-Key: ${DT_APIKEY}" \
+            -H "Content-Type: application/json" \
+            -d "${PAYLOAD}" \
+            "https://${DT_HOST}/api/v1/bom"
 
       - name: Get DTrack project URL
         id: dtrack-url


### PR DESCRIPTION
## Summary

- `DependencyTrack/gh-upload-sbom@v3` (latest: `v3.1.0`) uses `node20` runtime — deprecated in GitHub Actions, no upstream fix exists
- Replaces the action with an equivalent `run:` step using `base64` + `jq` + `curl`
- Replicates the same `PUT /api/v1/bom` JSON payload the action sends: `projectName`, `projectVersion`, `autoCreate: true`, `bom` (base64, UTF-8 BOM stripped), `projectTags` (comma-separated → `[{name}]` array)
- All secrets via `env:` vars — no injection risk

All other actions in the workflows are already on node24 or composite.

## Test plan

- [ ] Trigger SBOM workflow — "Upload SBoM to Dependency Track" step succeeds
- [ ] Project appears/updates in DTrack UI with correct tags
- [ ] No node20 deprecation warnings in workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)