### PR TITLE
fix(sbom): avoid ARG_MAX limit when uploading large SBoMs to DTrack

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -90,20 +90,18 @@ jobs:
           PROJECT_VERSION: ${{ github.sha }}
           PROJECT_TAGS: "${{ github.repository }}, ${{ github.ref_type }}, ${{ github.ref }}"
         run: |
-          BOM_B64=$(base64 -w 0 sbom.json)
-          [[ "${BOM_B64}" == 77u/* ]] && BOM_B64="${BOM_B64:4}"
           TAGS=$(printf '%s' "${PROJECT_TAGS}" | jq -Rc 'split(",") | map(gsub("^ +| +$"; "") | {name: .})')
-          PAYLOAD=$(jq -n \
+          jq -n \
             --arg name "${PROJECT_NAME}" \
             --arg version "${PROJECT_VERSION}" \
             --argjson tags "${TAGS}" \
-            --arg bom "${BOM_B64}" \
-            '{projectName: $name, projectVersion: $version, autoCreate: true, bom: $bom, projectTags: $tags}')
-          curl -sf -X PUT \
-            -H "X-Api-Key: ${DT_APIKEY}" \
-            -H "Content-Type: application/json" \
-            -d "${PAYLOAD}" \
-            "https://${DT_HOST}/api/v1/bom"
+            --rawfile bom sbom.json \
+            '{projectName: $name, projectVersion: $version, autoCreate: true, bom: ($bom | ltrimstr("\ufeff") | @base64), projectTags: $tags}' \
+          | curl -sf -X PUT \
+              -H "X-Api-Key: ${DT_APIKEY}" \
+              -H "Content-Type: application/json" \
+              -d @- \
+              "https://${DT_HOST}/api/v1/bom"
 
       - name: Get DTrack project URL
         id: dtrack-url


### PR DESCRIPTION
## Summary

- `base64 -w 0 sbom.json` for large repos produces a string that exceeds the kernel ARG_MAX when passed to `jq` via `--arg bom` — metasearch hit this: `jq: Argument list too long` / exit code 126
- Replaces the `BOM_B64` shell variable + `--arg` approach with:
  - `--rawfile bom sbom.json` — jq reads the file directly, no shell intermediate
  - `$bom | ltrimstr("﻿") | @base64` — strips UTF-8 BOM then encodes within jq
  - `curl -d @-` — reads payload from stdin, no shell variable for the full JSON blob

Fixes: https://github.com/pgmac-net/metasearch/actions/runs/27493686604/job/81263679233

## Test plan

- [ ] Trigger SBOM workflow on metasearch (or any repo with a large SBoM) — upload step succeeds
- [ ] Project appears/updates in DTrack with correct tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)